### PR TITLE
[#19] 인증 방식 변경에 따른 Bearer 헤더 추가, 리프레시 로직 헤더에 구현

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,30 +1,72 @@
-import { useEffect, useState } from "react";
-import { NavLink } from "react-router-dom";
+import {useEffect, useState} from "react";
+import {NavLink} from "react-router-dom";
 import jwt_decode from "jwt-decode";
 import {Button, IconButton} from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import {UserInfo} from "../../types/UMSType";
+import {plogAuthAxios} from "../../config";
 
 
-export default function Header (){
+export default function Header() {
 
     const token = localStorage.getItem('token')
     const [userInfo, setUserInfo] = useState<UserInfo>({});
 
-    useEffect(()=>{
-        if(token){
-            const decoded = jwt_decode(localStorage.getItem('token')||'')
-            setUserInfo(decoded||{})
+    // 토큰 리프레시 남은 시간 (초기는 30분)
+    const [expiredInterval, setExpiredInterval] = useState<number>(1800);
+
+    useEffect(() => {
+        if (!token) return;
+
+        try {
+            const decoded = jwt_decode(token) as UserInfo
+            if (!decoded) return;
+            // 만료 시간이 지난 토큰인 경우 로그아웃
+            if ((decoded.exp ? decoded.exp : 0) < (new Date().getTime() / 1000 as number)) {
+                localStorage.removeItem('token')
+                return;
+            }
+            setUserInfo(decoded)
+        } catch (error) {
+            console.log("Invalid Token Spectified: ", error)
         }
+
     }, [token])
 
+    useEffect(() => {
+        // 주기적으로 토큰의 expired를 체크하여 남은 시간을 계산 (1분마다 실행)
+        const interval = setInterval(() => {
+            if (!userInfo.exp) return;
+            const currentTime = new Date().getTime() / 1000;
+            setExpiredInterval(userInfo.exp - currentTime);
+        }, 60000);
+
+        return () => {
+            clearInterval(interval);
+        };
+    }, [userInfo.exp]);
+
+
+    useEffect(() => {
+        // 인증 토큰의 남은 만료 시간이 10분 초과인 경우 리프레시 하지 않음
+        if (expiredInterval > 600) {
+            return;
+        }
+        
+        // 엑세스 토큰 리프레시
+        plogAuthAxios.post("/auth/refresh-access-token").then(
+            (response: any) => {
+                localStorage.setItem("token", response.data.data.token.accessToken)
+            }
+        )
+    }, [expiredInterval])
 
     return (
-        <div className='header inner-container' >
+        <div className='header inner-container'>
             <div><a href='/'><span className='logo'>Plog</span></a></div>
             <div>
                 <NavLink to='/search'>
-                    <IconButton  aria-label="search" disabled color="primary">
+                    <IconButton aria-label="search" disabled color="primary">
                         <SearchIcon className='search-btn'/>
                     </IconButton>
                 </NavLink>

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,14 @@ export const plogAxios = axios.create({
     baseURL: process.env.REACT_APP_BASE_API_URL,
     headers: {
         'Content-Type': 'application/json',
-        'X-AUTH-TOKEN': localStorage.getItem('token')
+    }
+})
+
+export const plogAuthAxios = axios.create({
+    baseURL: process.env.REACT_APP_BASE_API_URL,
+    headers: {
+        'Content-Type': 'application/json',
+        'Authorization': "Bearer " + localStorage.getItem('token')
     }
 })
 


### PR DESCRIPTION
resolved: #19 

# 설명
- 인증 방식 변경에 따라 Bearer을 헤더에 추가하였습니다.
- 리프레시 로직을 헤더 컴포넌트에 구현하였습니다. (더이상 로컬 스토리지를 비울 필요 없습니다.)
- 토큰이 만료된 경우 자동으로 로그아웃 처리하도록 변경하였습니다.
- Axios를 인증 토큰을 넣는 경우(plogAuthAxios), 인증 토큰을 넣지 않는 경우(plogAxios)로 분기하였습니다.
- Auth가 필요한 경우가 뭔지 잘 모르겠어서, 해당 부분 알려주시면 제가 해당 PR에서 수정하도록 하겠습니다. (@SHINSOJIN )