### PR TITLE
[#56~#60,#62,#63,#66] 다크모드로 회원가입 시 색상 구분 명확하게 수정, 인증번호 일치 확인 로직 변경, 회원가입 관련 이슈 일괄 수정

### DIFF
--- a/src/assets/css.css
+++ b/src/assets/css.css
@@ -18,6 +18,8 @@ html[class~='dark'] {
     --form-border: #ECECEC;
     --error: #f56f6f;
     --important: #ef3636;
+    --disabled: #dedede;
+    --mode: dark;
 
 }
 
@@ -27,7 +29,7 @@ html[class~='light'] {
     --bg-element1: #FFFFFF;
     --bg-element2: #F8F9FA;
     --bg-element3: #F1F3F5;
-    --bg-element4: #343A40;
+    --bg-element4: #868E96;
     --text1: #212529;
     --text2: #495057;
     --text3: #868E96;
@@ -39,7 +41,10 @@ html[class~='light'] {
     --form-border: #ADB5BD;
     --error: #ff5b5b;
     --important: #ef3636;
+    --disabled: #9f9f9f;
+    --mode: light;
 }
+
 
 /* 레이아웃 공용 디자인 */
 body {
@@ -292,8 +297,8 @@ div, p, h1, h2, h3, h4, h5, h6, input {
     color: var(--text3);
     border: none;
     border-bottom: 2px solid var(--text3);
+    color-scheme: var(--mode);
 }
-
 
 .step2-container .signup-inputs .birth-input:focus {
     outline: 0;

--- a/src/assets/css.css
+++ b/src/assets/css.css
@@ -19,6 +19,7 @@ html[class~='dark'] {
     --error: #f56f6f;
     --important: #ef3636;
     --disabled: #dedede;
+    --disabled2: #9b9b9b;
     --mode: dark;
 
 }
@@ -42,6 +43,7 @@ html[class~='light'] {
     --error: #ff5b5b;
     --important: #ef3636;
     --disabled: #9f9f9f;
+    --disabled2: #9f9f9f;
     --mode: light;
 }
 

--- a/src/pages/signin/ForgotPassword.tsx
+++ b/src/pages/signin/ForgotPassword.tsx
@@ -1,5 +1,5 @@
 import {useState} from "react";
-import {Box, Button, Grid, TextField, Typography} from '@mui/material';
+import {Box, Button, CircularProgress, Grid, TextField, Typography} from '@mui/material';
 import {CodeParams} from "../../types/UMSType";
 import {getPlogAxios} from "../../modules/axios";
 
@@ -9,11 +9,13 @@ export function ForgotPassword() {
 
     const [account, setAccount] = useState<string>(''); // 유저 이메일
     const [sendEmail, setSendEmail] = useState<boolean>(false); // 인증코드 메일 전송 체크
+    const [load, setLoad] = useState<boolean>(false)// 인증코드 전송 로딩스피너
     const [verifyCode, setVerifyCode] = useState<string>(''); // 메일 인증코드
     const [verifyToken, setVerifyToken] = useState<string>(''); // 인증코드 맞으면 리턴되는 토큰값
     const [password, setPassword] = useState<string>(''); // 유저 비밀번호
 
     const sendEmailRequest = () => {
+        setLoad(true)
         const params = {
             "email": account
         }
@@ -21,10 +23,12 @@ export function ForgotPassword() {
             .then(res => {
                 if (res.status === 200 || res.status === 204) {
                     setSendEmail(true)
+                    setLoad(false)
                 }
             })
             .catch(err => {
-                console.log(err.message)
+                setLoad(false)
+                alert(err.message)
             })
     }
 
@@ -81,11 +85,12 @@ export function ForgotPassword() {
                             sx={{
                                 backgroundColor:sendEmail ? 'var(--primary1)' : '',
                                 color:sendEmail?'#fff':'var(--border)',
-                                border: sendEmail?'none':'1px solid var(--border)',
+                                border: sendEmail?'none':'1px solid var(--form-border)',
+                                '&:hover':{border: sendEmail?'none':'1px solid var(--form-border)', backgroundColor:sendEmail ? 'var(--primary1)' : '#fff',}
                             }}
                             onClick={sendEmailRequest}
                     >
-                        인증코드 전송
+                        {load ? <CircularProgress sx={{color: 'var(--form-border)'}} size="1.5rem"/> : '인증코드 전송'}
                     </Button>
                     <Grid container spacing={2} style={{display: sendEmail ? 'block' : 'none'}}>
                         <Grid item xs={12} sm={6}>

--- a/src/pages/signin/ForgotPassword.tsx
+++ b/src/pages/signin/ForgotPassword.tsx
@@ -1,4 +1,5 @@
 import {useState} from "react";
+import {useNavigate} from "react-router-dom";
 import {Box, Button, CircularProgress, Grid, TextField, Typography} from '@mui/material';
 import {CodeParams} from "../../types/UMSType";
 import {getPlogAxios} from "../../modules/axios";
@@ -7,6 +8,7 @@ import {getPlogAxios} from "../../modules/axios";
 
 export function ForgotPassword() {
 
+    const navigate = useNavigate()
     const [account, setAccount] = useState<string>(''); // 유저 이메일
     const [sendEmail, setSendEmail] = useState<boolean>(false); // 인증코드 메일 전송 체크
     const [load, setLoad] = useState<boolean>(false)// 인증코드 전송 로딩스피너
@@ -37,20 +39,20 @@ export function ForgotPassword() {
             "email": account,
             "verifyCode": verifyCode
         }
-        if (verifyCode.length === 6 || e.keyCode === 9 || e.keyCode === 13) {
-            getPlogAxios().post('/auth/verify-find-password-email', params)
-                .then(res => {
-                    if (res.status === 200) {
-                        const token = res.data.verifyToken //인증번호 일치하면 토큰획득
-                        setVerifyToken(token)
-                    }
-                })
-                .catch(err => {
-                    console.log(err.message)
-                    setVerifyToken('')
-                })
-        } else {
-            setVerifyToken('')
+        if(e.keyCode === 13){
+            if (verifyCode.length === 6 && verifyToken === '' ) {
+                getPlogAxios().post('/auth/verify-find-password-email', params)
+                    .then(res => {
+                        if (res.status === 200) {
+                            const token = res.data.verifyToken //인증번호 일치하면 토큰획득
+                            setVerifyToken(token)
+                        }
+                    })
+                    .catch(err => {
+                        console.log(err.message)
+                        setVerifyToken('')
+                    })
+            }
         }
     }
 
@@ -62,7 +64,14 @@ export function ForgotPassword() {
             "verifyToken": verifyToken
         }
         getPlogAxios().post('/auth/change-password', params)
-            .then(res => alert(res.status))
+            .then(res => {
+                if(res.status === 204 || res.status === 200){
+                    alert('비밀번호가 변경되었습니다. 로그인 페이지로 이동합니다.')
+                    navigate('/sign-in')
+                }else {
+                    alert('로그인 변경에 실패했습니다. 다시 시도해주십시오.')
+                }
+            })
             .catch(err => alert(err.message))
     }
 
@@ -86,7 +95,8 @@ export function ForgotPassword() {
                                 backgroundColor:sendEmail ? 'var(--primary1)' : '',
                                 color:sendEmail?'#fff':'var(--border)',
                                 border: sendEmail?'none':'1px solid var(--form-border)',
-                                '&:hover':{border: sendEmail?'none':'1px solid var(--form-border)', backgroundColor:sendEmail ? 'var(--primary1)' : '#fff',}
+                                '&.Mui-disabled':{ borderColor: 'var(--disabled)', color:'var(--disabled)'},
+                                '&:hover':{border: sendEmail?'none':'1px solid var(--form-border)', backgroundColor:sendEmail ? 'var(--primary1)' : 'var(--bg-card1)',}
                             }}
                             onClick={sendEmailRequest}
                     >
@@ -95,23 +105,26 @@ export function ForgotPassword() {
                     <Grid container spacing={2} style={{display: sendEmail ? 'block' : 'none'}}>
                         <Grid item xs={12} sm={6}>
                             <TextField variant="standard" autoFocus autoComplete="given-name" label="인증번호" name="인증번호"
-                                       inputProps={{maxLength: 6,}}
                                        sx={{
-                                           '& .MuiFormHelperText-root':{color:'var(--error)'},
+                                           '& .MuiFormHelperText-root':{color:'var(--primary1)'},
                                            '& input.MuiInputBase-input':{color: 'var(--text1)', borderBottom: '1px solid var(--form-border)'},
                                            '& label.MuiFormLabel-root':{color: 'var(--text1)'},
+                                           '& input.Mui-disabled':{color: 'var(--primary1)',  WebkitTextFillColor: "var(--text1)",},
                                        }}
                                        onChange={(e) => setVerifyCode(e.target.value)}
                                        onKeyDown={codeCheckRequest}
-                                       helperText={!!verifyToken || verifyCode.length === 0 ? '' : '인증번호가 일치하지 않습니다.'}
+                                       helperText={!!verifyToken ? '인증번호가 일치합니다' : '인증번호가 일치하지 않습니다.'}
                                        color={!!verifyToken ? 'success' : 'primary'}
                                        required
+                                       disabled={!!verifyToken}
+                                       error={!!verifyToken === false}
                             />
                         </Grid>
                     </Grid>
 
                     <TextField
                         variant="standard" fullWidth name="password" autoComplete="new-password" label="비밀번호"
+                        placeholder='변경하실 비밀번호를 입력해주세요'
                         type="password" margin="normal"
                         onChange={(e) => setPassword(e.target.value)}
                         sx={{
@@ -122,7 +135,7 @@ export function ForgotPassword() {
                     />
 
 
-                    <Button variant='contained'
+                    <Button variant='contained' className='btn-full'
                             sx={{mt:1.5,color:'#fff',fontSize:'15px', width:'100%', height:"50px", backgroundColor:'var(--primary1)'}}
                             onClick={changePassword}>
                         비밀번호 변경하기

--- a/src/pages/signin/SignIn.tsx
+++ b/src/pages/signin/SignIn.tsx
@@ -8,6 +8,7 @@ export function SignIn() {
     const navigate = useNavigate();
     const [email, setEmail] = useState<string>('');
     const [password, setPassword] = useState<string>('');
+    const [helperMsg, setHelperMsg] = useState<string | null>(null);
 
     const loginRequest = () => {
         const params: Login = {
@@ -24,9 +25,11 @@ export function SignIn() {
                 switch (getErrorCode(err) ?? "UNKNOWN") {
                     case "ERR_LOGIN_FAILED":
                         console.log("로그인에 실패")
+                        setHelperMsg(err?.response?.data?.message)
                         break;
                     case "UNKNOWN":
                         console.log("알 수 없는 오류입니다.")
+                        setHelperMsg(err?.response?.data?.message)
                         break;
                 }
             })
@@ -50,12 +53,10 @@ export function SignIn() {
                                    if(e.keyCode === 13){
                                        loginRequest()
                                    }
-                               }}
-                        />
+                               }}/>
                     </div>
-                    <Button className='login-btn-full' variant='contained'
-                            onClick={loginRequest}
-                    >Login</Button>
+                    {helperMsg && <p style={{color: 'var(--error)', fontSize:'13px'}}>{helperMsg}</p>}
+                    <Button className='login-btn-full' variant='contained' onClick={loginRequest}>Login</Button>
                     <p className='sentence'>
                         <span className='forgot-pw' onClick={() => navigate('/forgot-password')}>비밀번호 찾기 </span>
                         |

--- a/src/pages/signin/SignUp.tsx
+++ b/src/pages/signin/SignUp.tsx
@@ -87,7 +87,7 @@ export function SignUp() {
             "firstName": firstName,
             "introHTML": introHtml,
             "lastName": lastName,
-            "nickName": nickName,
+            "nickname": nickName,
             "password": password,
             "sex": sex,
             "shortIntro": shortIntro,
@@ -95,14 +95,13 @@ export function SignUp() {
         }
         getPlogAxios().post('/auth/join', params)
             .then((res: any) => {
-                if (res.status === 200) {
-                    console.log(res.status)
+                if (res.status === 200 || res.status === 201) {
                     setActiveStep(2)
                 } else {
                     console.log(res.status)
                 }
             })
-            .catch(err => console.log(err.message))
+            .catch(err => alert(err.message + '필수 입력 칸을 모두 채워주세요.'))
     }
 
 

--- a/src/pages/signin/SignUp.tsx
+++ b/src/pages/signin/SignUp.tsx
@@ -13,7 +13,7 @@ export function SignUp() {
 
     const steps = ['이메일 인증', '상세정보 기입', '가입완료',];
 
-    const [activeStep, setActiveStep] = useState<number>(0)
+    const [activeStep, setActiveStep] = useState<number>(1)
     //STEP 1
     const [account, setAccount] = useState<string>(''); // 유저 이메일
     const [sendEmail, setSendEmail] = useState<boolean>(false); // 인증코드 메일 전송 체크
@@ -131,6 +131,8 @@ export function SignUp() {
                         {steps.map((label) => (
                             <Step key={label}
                                   sx={{
+                                      '& .MuiStepLabel-root .Mui-disabled': {color: 'var(--text3)',},
+                                      '& .MuiStepLabel-root .Mui-disabled circle': {color: 'var(--bg-element4)',},
                                       '& .MuiStepLabel-root .Mui-completed': {color: 'var(--primary1)',},
                                       '& .MuiStepLabel-root .Mui-active': {color:  'var(--primary1)'},
                                   }}>
@@ -154,6 +156,7 @@ export function SignUp() {
                                 backgroundColor:sendEmail ? 'var(--primary1)' : '',
                                 color:sendEmail?'#fff':'var(--border)',
                                 border: sendEmail?'none':'1px solid var(--form-border)',
+                                '&.Mui-disabled':{ borderColor: 'var(--disabled)', color:'var(--disabled)'},
                                 '&:hover':{border: sendEmail?'none':'1px solid var(--form-border)', backgroundColor:sendEmail ? 'var(--primary1)' : '#fff',}
                             }}
                             variant={sendEmail ? 'contained' : 'outlined'}

--- a/src/pages/signin/SignUp.tsx
+++ b/src/pages/signin/SignUp.tsx
@@ -5,7 +5,7 @@ import {Box, Button, Grid, Link, Step, StepLabel, Stepper, TextField, Typography
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import {email} from '../../modules/validation'
 import {CodeParams, SignupParams} from "../../types/UMSType";
-import {getPlogAxios} from "../../modules/axios";
+import {getPlogAxios, plogAuthAxios} from "../../modules/axios";
 
 
 export function SignUp() {
@@ -13,7 +13,7 @@ export function SignUp() {
 
     const steps = ['이메일 인증', '상세정보 기입', '가입완료',];
 
-    const [activeStep, setActiveStep] = useState<number>(0)
+    const [activeStep, setActiveStep] = useState<number>(1)
     //STEP 1
     const [account, setAccount] = useState<string>(''); // 유저 이메일
     const [sendEmail, setSendEmail] = useState<boolean>(false); // 인증코드 메일 전송 체크
@@ -28,6 +28,7 @@ export function SignUp() {
     const [sex, setSex] = useState<string>('');
     const [birth, setBirth] = useState<string>('');
     const [blogName, setBlogName] = useState<string>('');
+    const [blogNameErr, setBlogNameErr] = useState<string>('');
     const [nickName, setNickName] = useState<string>('');
     const [shortIntro, setShortIntro] = useState<string>('');
     const [introHtml, setIntroHtml] = useState<string>('');
@@ -70,7 +71,7 @@ export function SignUp() {
                     }
                 })
                 .catch(err => {
-                    console.log(err.message)
+                    console.error(err.message)
                     setVerifyToken('')
                 })
         } else {
@@ -78,8 +79,7 @@ export function SignUp() {
         }
     }
 
-    const signupRequest = () => {
-
+    const signUpRequest = () => {
         const params: SignupParams = {
             "birth": birth,
             "blogName": blogName,
@@ -117,6 +117,19 @@ export function SignUp() {
         }
 
         return false
+    }
+
+    const checkDuplicateBlogId = () =>{
+        const params = {blogName : blogName}
+        getPlogAxios().post('/blogs/check-blog-name-exist', params)
+            .then(res => {
+                if(res.status === 204 || res.status === 200){
+                    setBlogNameErr('')
+                }
+            })
+            .catch(err => {
+                setBlogNameErr(err.response.data.message)
+            })
     }
 
     return (
@@ -238,8 +251,11 @@ export function SignUp() {
                     </div>
 
                     <div className='signup-inputs'>
-                        <input className='signup-input' type='text' placeholder='* 블로그 이름(4자 이상, 소문자, 숫자만)'
-                               onChange={(e) => setBlogName(e.target.value)}/>
+                        <input className='signup-input' type='text' placeholder='* 블로그 이름(4자 이상, 영문 소문자와 숫자만 조합가능합니다.)'
+                               onChange={(e) => setBlogName(e.target.value)}
+                               onBlur={checkDuplicateBlogId}
+                        />
+                        {blogName && blogNameErr && <p style={{color: '#d32f2f', fontSize:'13px', marginTop:'4px'}}>{blogNameErr}</p>}
                     </div>
                     <div className='signup-inputs'>
                         <input className='signup-input' type='text' placeholder='* 닉네임'
@@ -247,12 +263,13 @@ export function SignUp() {
                     </div>
                     <div className='signup-inputs'>
                         <input className='signup-input' type='text' placeholder='* 본인 소개'
-                               onChange={(e) => setShortIntro(e.target.value)}/>
+                               onChange={(e) => setShortIntro(e.target.value)}
+                        />
                     </div>
                     <Button className='join-btn'
                             variant='contained'
                             sx={{backgroundColor: 'var(--primary1)',color: '#fff', ':hover':{backgroundColor: 'var(--primary2)'}}}
-                            onClick={signupRequest}>회원가입</Button>
+                            onClick={signUpRequest}>회원가입</Button>
                 </div>
 
                 <div className='signup-form'

--- a/src/pages/signin/SignUp.tsx
+++ b/src/pages/signin/SignUp.tsx
@@ -13,7 +13,7 @@ export function SignUp() {
 
     const steps = ['이메일 인증', '상세정보 기입', '가입완료',];
 
-    const [activeStep, setActiveStep] = useState<number>(1)
+    const [activeStep, setActiveStep] = useState<number>(0)
     //STEP 1
     const [account, setAccount] = useState<string>(''); // 유저 이메일
     const [sendEmail, setSendEmail] = useState<boolean>(false); // 인증코드 메일 전송 체크
@@ -151,13 +151,13 @@ export function SignUp() {
                                sx={{'& .MuiFormHelperText-root':{color:'var(--error)'}}}
                                required/>
                     <Button className='email-chk' size="small"
-                            disabled={regCheck(account, 'email') === false || account === ''}
+                            disabled={regCheck(account, 'email') === false || account === '' || !!verifyToken}
                             sx={{
                                 backgroundColor:sendEmail ? 'var(--primary1)' : '',
                                 color:sendEmail?'#fff':'var(--border)',
                                 border: sendEmail?'none':'1px solid var(--form-border)',
                                 '&.Mui-disabled':{ borderColor: 'var(--disabled)', color:'var(--disabled)'},
-                                '&:hover':{border: sendEmail?'none':'1px solid var(--form-border)', backgroundColor:sendEmail ? 'var(--primary1)' : '#fff',}
+                                '&:hover':{border: sendEmail?'none':'1px solid var(--form-border)', backgroundColor:sendEmail ? 'var(--primary1)' : 'var(--bg-car1)',}
                             }}
                             variant={sendEmail ? 'contained' : 'outlined'}
                             onClick={sendEmailRequest}>
@@ -170,9 +170,14 @@ export function SignUp() {
                                        onChange={(e) => setVerifyCode(e.target.value)}
                                        onKeyDown={codeCheckRequest}
                                        helperText={!!verifyToken ? '인증번호가 일치합니다' : '인증번호가 일치하지 않습니다.'}
-                                       sx={{'& .MuiFormHelperText-root':{color:'var(--primary1)'}}}
+                                       sx={{
+                                           '& .MuiFormHelperText-root':{color:'var(--primary1)'},
+                                           '& .MuiFormHelperText-root.Mui-error':{color:'#d32f2f'},
+                                           '& input.Mui-disabled':{ WebkitTextFillColor: "var(--text1)",color: 'var(--primary1)'},
+                                       }}
                                        color={!!verifyToken ? 'success' : 'primary'}
                                        required
+                                       disabled={!!verifyToken}
                                        error={!!verifyToken === false}
                             />
                         </Grid>
@@ -188,7 +193,9 @@ export function SignUp() {
                                onChange={(e) => setPasswordConfirm(e.target.value)}
                                helperText={passwordConfirm===null ? '' : password === passwordConfirm ? '비밀번호가 일치합니다' : '비밀번호가 일치하지 않습니다'}
                                error={password !== passwordConfirm && passwordConfirm !== null}
-                               sx={{'& .MuiFormHelperText-root':{color:'var(--primary1)'}}}
+                               sx={{'& .MuiFormHelperText-root':{color:'var(--primary1)'},
+                                   '& .MuiFormHelperText-root.Mui-error':{color:'#d32f2f'},
+                               }}
                                required
                     />
                     <Button variant='contained' className='btn-full'

--- a/src/pages/signin/SignUp.tsx
+++ b/src/pages/signin/SignUp.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react'
 import {useNavigate} from 'react-router-dom';
 import {Box, Button, Grid, Link, Step, StepLabel, Stepper, TextField, Typography,CircularProgress} from '@mui/material';
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
-import {email, required} from '../../modules/validation'
+import {email} from '../../modules/validation'
 import {CodeParams, SignupParams} from "../../types/UMSType";
 import {getPlogAxios} from "../../modules/axios";
 
@@ -21,7 +21,7 @@ export function SignUp() {
     const [verifyCode, setVerifyCode] = useState<string>(''); // 메일 인증코드
     const [verifyToken, setVerifyToken] = useState<string>(''); // 인증코드 맞으면 리턴되는 토큰값
     const [password, setPassword] = useState<string>(''); // 유저 비밀번호
-    const [passwordConfirm, setPasswordConfirm] = useState<string>(''); // 유저 비밀번호
+    const [passwordConfirm, setPasswordConfirm] = useState<string | null>(null); // 유저 비밀번호
     //STEP 2
     const [firstName, setFirstName] = useState<string>('');
     const [lastName, setLastName] = useState<string>('');
@@ -31,24 +31,7 @@ export function SignUp() {
     const [nickName, setNickName] = useState<string>('');
     const [shortIntro, setShortIntro] = useState<string>('');
     const [introHtml, setIntroHtml] = useState<string>('');
-    const [sent, setSent] = useState<boolean>(false);
 
-
-    // const validate = (values: { [index: string]: string }) => {
-    //     const errors = required(['firstName', 'lastName', 'email', 'password'], values);
-    //
-    //     if (!errors.email) {
-    //         const emailError = email(values.email);
-    //         if (emailError) {
-    //             errors.email = emailError;
-    //         }
-    //     }
-    //     return errors;
-    // };
-
-    // const handleSubmit = () => {
-    //     setSent(true);
-    // };
 
     const sendEmailRequest = () => {
         setLoad(true)
@@ -78,7 +61,7 @@ export function SignUp() {
             "email": account,
             "verifyCode": verifyCode
         }
-        if (verifyCode.length === 6 || e.keyCode === 9 || e.keyCode === 13) {
+        if (verifyCode.length === 6 && (e.keyCode === 9 || e.keyCode === 13) ) {
             getPlogAxios().post('/auth/verify-join-email', params)
                 .then(res => {
                     if (res.status === 200) {
@@ -175,18 +158,19 @@ export function SignUp() {
                             }}
                             variant={sendEmail ? 'contained' : 'outlined'}
                             onClick={sendEmailRequest}>
-                        {load ? <CircularProgress sx={{color: 'var(--form-border)'}} size="1.5rem"/> : '인증코드 전송'}
+                        {load ? <CircularProgress sx={{color: sendEmail ? '#fff' : 'var(--form-border)'}} size="1.5rem"/> : sendEmail ? '재전송' : '인증코드 전송'}
                     </Button>
                     {sendEmail && <Grid container spacing={2}>
                         <Grid item xs={12} sm={6}>
                             <TextField variant="standard" autoFocus autoComplete="given-name" label="인증번호" name="인증번호"
-                                       inputProps={{maxLength: 6,}}
+                                       inputProps={{maxLength: 6}}
                                        onChange={(e) => setVerifyCode(e.target.value)}
                                        onKeyDown={codeCheckRequest}
-                                       helperText={!!verifyToken || verifyCode.length === 0 ? '' : '인증번호가 일치하지 않습니다.'}
-                                       sx={{'& .MuiFormHelperText-root': {color: 'var(--error)'}}}
+                                       helperText={!!verifyToken ? '인증번호가 일치합니다' : '인증번호가 일치하지 않습니다.'}
+                                       sx={{'& .MuiFormHelperText-root':{color:'var(--primary1)'}}}
                                        color={!!verifyToken ? 'success' : 'primary'}
                                        required
+                                       error={!!verifyToken === false}
                             />
                         </Grid>
                     </Grid>}
@@ -199,11 +183,19 @@ export function SignUp() {
                     <TextField variant="standard" fullWidth name="password" autoComplete="new-password" label="비밀번호 확인"
                                type="password" margin="normal"
                                onChange={(e) => setPasswordConfirm(e.target.value)}
-                               helperText={password === passwordConfirm && passwordConfirm.length > 0 ? '비밀번호가 일치합니다' : ''}
+                               helperText={passwordConfirm===null ? '' : password === passwordConfirm ? '비밀번호가 일치합니다' : '비밀번호가 일치하지 않습니다'}
+                               error={password !== passwordConfirm && passwordConfirm !== null}
                                sx={{'& .MuiFormHelperText-root':{color:'var(--primary1)'}}}
                                required
                     />
-                    <Button variant='contained' className='btn-full' onClick={() => setActiveStep(1)}>
+                    <Button variant='contained' className='btn-full'
+                            onClick={() => {
+                                if(!!account && !!verifyToken && passwordConfirm===password){
+                                    setActiveStep(1)
+                                }else {
+                                    alert('필드를 모두 입력해주세요')
+                                }
+                            }}>
                         다음 단계 진행하기
                     </Button>
                 </Box>

--- a/src/pages/signin/SignUp.tsx
+++ b/src/pages/signin/SignUp.tsx
@@ -165,11 +165,17 @@ export function SignUp() {
                                helperText={regCheck(account, 'email') ? '' : '올바른 이메일 형식을 입력해주세요'}
                                sx={{'& .MuiFormHelperText-root':{color:'var(--error)'}}}
                                required/>
-                    <Button className='email-chk' size="small" color='success'
+                    <Button className='email-chk' size="small"
                             disabled={regCheck(account, 'email') === false || account === ''}
+                            sx={{
+                                backgroundColor:sendEmail ? 'var(--primary1)' : '',
+                                color:sendEmail?'#fff':'var(--border)',
+                                border: sendEmail?'none':'1px solid var(--form-border)',
+                                '&:hover':{border: sendEmail?'none':'1px solid var(--form-border)', backgroundColor:sendEmail ? 'var(--primary1)' : '#fff',}
+                            }}
                             variant={sendEmail ? 'contained' : 'outlined'}
                             onClick={sendEmailRequest}>
-                        {load ? <CircularProgress color="success" size="1.5rem"/> : '인증코드 전송'}
+                        {load ? <CircularProgress sx={{color: 'var(--form-border)'}} size="1.5rem"/> : '인증코드 전송'}
                     </Button>
                     {sendEmail && <Grid container spacing={2}>
                         <Grid item xs={12} sm={6}>

--- a/src/pages/signin/SignUp.tsx
+++ b/src/pages/signin/SignUp.tsx
@@ -13,7 +13,7 @@ export function SignUp() {
 
     const steps = ['이메일 인증', '상세정보 기입', '가입완료',];
 
-    const [activeStep, setActiveStep] = useState<number>(1)
+    const [activeStep, setActiveStep] = useState<number>(0)
     //STEP 1
     const [account, setAccount] = useState<string>(''); // 유저 이메일
     const [sendEmail, setSendEmail] = useState<boolean>(false); // 인증코드 메일 전송 체크

--- a/src/types/UMSType.ts
+++ b/src/types/UMSType.ts
@@ -18,7 +18,7 @@ export interface SignupParams {
     "firstName": string;
     "introHTML": string;
     "lastName": string;
-    "nickName": string;
+    "nickname": string;
     "password": string;
     "sex": string;
     "shortIntro": string;

--- a/src/types/UMSType.ts
+++ b/src/types/UMSType.ts
@@ -8,7 +8,7 @@ export interface Login {
 //회원가입
 export interface CodeParams {
     "email": string;
-    "verifyCode": string;
+    "verifyCode": string | null;
 }
 
 export interface SignupParams {


### PR DESCRIPTION
resolved: #56 
resolved: #57 
resolved: #58 
resolved: #59 
resolved: #60 
resolved: #62
resolved: #63 
resolved: #66 

# 설명

계정과 관련된 버그를 수정했습니다. 
 
1. 회원가입 
 - 다크모드로 진행 시 잘 안보였던 아이콘 색상 변경
 - 첫번째 단계 필드 전부 입력해야 다음 단계 진행할 수 있도록 수정
 - 인증번호 일치 확인 로직 변경 (verifyToken 획득하면 인증번호 수정 및 재요청 불가, 비밀번호 찾기 동시 적용)
 - 인증번호 요청 시 로딩 스피너 추가 (비밀번호 찾기 동시 적용)
 - 블로그명 중복 체크 추가 에러메세지 추가 


2. 유효성 체크
- 회원가입, 로그인 에러 발생 시 메세지 추가
