### PR TITLE
[#114] 홈포스팅 제목이 길 경우 2번째 줄에서 말줄임표 적용

### DIFF
--- a/src/components/blog/PostCard.tsx
+++ b/src/components/blog/PostCard.tsx
@@ -61,13 +61,15 @@ const PostCard: React.FC<ChildProps> = ({ post }) => {
                 alt="썸네일 사진"
                 onClick={moveToPost}/>}
             <CardContent sx={{paddingBottom:0,}}>
-                <Typography variant="body1" color="text.first" sx={{height: '48px'}}>
+                <Typography variant="body1" color="text.first"
+                            sx={{height: '48px', overflowY:'hidden', textOverflow: 'ellipsis',  WebkitLineClamp:  '2', display:'-webkit-box',
+                                WebkitBoxOrient: 'vertical'}}>
                     {post.title}
                 </Typography>
                 <Typography id='postcard-summary' variant="body2" color="text.secondary"
                             sx={{
                                 height: !!post.thumbnailImageURL ? '80px' : '230px',
-                                '-webkit-line-clamp': !!post.thumbnailImageURL ? '4' : '12',
+                                WebkitLineClamp: !!post.thumbnailImageURL ? '4' : '12',
                             }}
                 >
                     {summary(post.htmlContent)}


### PR DESCRIPTION
resolved: #114

# 설명

홈포스팅에서 포스팅의 제목이 길 경우 2번째 줄부터 내용 생략 후 말줄임표를 추가했습니다. 
